### PR TITLE
BF: fix spelling typos across project code, docs, and templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Expfactory Deploy
 =================
 
-Django project for the managment and deployment of batteries of experiments.
+Django project for the management and deployment of batteries of experiments.
 
 History
 -------
@@ -21,7 +21,7 @@ The repos and their purpose from first iteration of Expfactory:
 And from the The second iteration of Expfactory:
 
 - `expfactory-experiments (github org)
-  <https://github.com/expfactory-experiments>`_: Seprated each experiment into
+  <https://github.com/expfactory-experiments>`_: Separated each experiment into
   their own repository.
 - `expfactory <https://github.com/expfactory/expfactory>`_: A utility to mint
   container images that allow given batteries to be reproducibly run.
@@ -36,7 +36,7 @@ integrate the tenets of reproducibility from the second iteration.
 
 Running Locally
 ---------------
-On a fresh clone a number of environemnt variables must be set for django to start properly:
+On a fresh clone a number of environment variables must be set for django to start properly:
 In a shell:
     mkdir -p ./.envs/.local
     touch -p ./.envs/.local/.postgres

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -33,7 +33,7 @@ CACHES = {
         "LOCATION": env("REDIS_URL"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            # Mimicing memcache behavior.
+            # Mimicking memcache behavior.
             # https://github.com/jazzband/django-redis#memcached-exceptions-behavior
             "IGNORE_EXCEPTIONS": True,
         },

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
 Project Configuration and Setup
 =================
 
-Django project for the managment and deployment of batteries of experiments.
+Django project for the management and deployment of batteries of experiments.
 
 .. image:: https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg?logo=cookiecutter
      :target: https://github.com/pydanny/cookiecutter-django/

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -9,7 +9,7 @@ This allows us to dynamically set where exactly jspsych is sending its data,
 and whtat urls to load once the experiment is complete.
 
 Each experiment lists what static resources it needs loaded in the html in its config.json,
-and the server populates these imports in the html before initalizing jspysch.
+and the server populates these imports in the html before initializing jspysch.
 
 .. _experiments-quickstart:
 Quickstart to Serving Experiments
@@ -38,7 +38,7 @@ Hey What about all those other buttons that cloned batteries have?
 Publish:
     Currently not used. Historically a battery would need to be published before subjects could complete it. Published batteries could not be modified in any way. This proved to restrictive when developing batteries and hasn't been removed.
 Preview Instructions/Consent:
-    Unlike `Preview` it does not generate a new subject and wont serve any experiments. Only used for testing to see how the Instructions and Consent render in a browser.
+    Unlike `Preview` it does not generate a new subject and won't serve any experiments. Only used for testing to see how the Instructions and Consent render in a browser.
 Details:
     A read only page with some additional information about the battery. It contains a list of all the subjects who have completed it, and results for that battery can be downloaded from there.
 Set Prolific URL:

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -22,7 +22,7 @@ Docstrings to Documentation
 
 The sphinx extension `apidoc <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html/>`_ is used to automatically document code using signatures and docstrings.
 
-Numpy or Google style docstrings will be picked up from project files and availble for documentation. See the `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/>`_ extension for details.
+Numpy or Google style docstrings will be picked up from project files and available for documentation. See the `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/>`_ extension for details.
 
 For an in-use example, see the `page source <_sources/users.rst.txt>`_ for :ref:`users`.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -43,7 +43,7 @@ Study Collection
 
 Database Models
 ----------------------------------------------------------------------
-To represent the above high level terms on the website there are a number of database models. Each of the following is the name of a python class. The classes are used to generate the databse schema, as well as instantiate instances of python objects when data from the database is accessed.
+To represent the above high level terms on the website there are a number of database models. Each of the following is the name of a python class. The classes are used to generate the database schema, as well as instantiate instances of python objects when data from the database is accessed.
 
 RepoOrigin
     Tracks a remote git repository that contains experiments.
@@ -82,8 +82,8 @@ Assignment
 
 Study
     An object that associates a battery and the details of a Study on
-    prolific's website.  When studies are first crated on the prolific site
-    they recieve a unique ID from prolific.
+    prolific's website.  When studies are first created on the prolific site
+    they receive a unique ID from prolific.
 
 StudyCollection
     Takes a set of batteries and creates a set of study objects for them,

--- a/docs/prolific.rst
+++ b/docs/prolific.rst
@@ -26,7 +26,7 @@ Workflow
 
 Prolific Caveats
 ----------------------------------------------------------------------
-When a study collection is pushed to prolific, a Prolific study is created for each battery in the study collection. Alongside each of these studies an empty participant group is created. Which Prolific participants can see the studys is soley determined by who is in their participant group.
+When a study collection is pushed to prolific, a Prolific study is created for each battery in the study collection. Alongside each of these studies an empty participant group is created. Which Prolific participants can see the studys is solely determined by who is in their participant group.
 
 To open a study to the public the screening criteria of the study on prolific will need to be edited on the prolific website. This can only be done when a study is in the `draft` state on prolific. For study collections with multiple batteries, only the first battery should be opened to the public, otherwise participants won't be required to complete the batteries in order, and we can't force them to take a break between batteries.
 

--- a/expfactory_deploy/experiments/views.py
+++ b/expfactory_deploy/experiments/views.py
@@ -143,7 +143,7 @@ class ExperimentInstanceDetail(LoginRequiredMixin, DetailView):
 '''
     This is called via HTMX when a new experiment_instance is selected from
     the drop down in the form, or an experiment_repo is dragged over to the
-    batteries current experiments colomn. In the case of the select HTMX
+    batteries current experiments column. In the case of the select HTMX
     encodes the select value as a query param whose key is the html `name`
     attribute. The value changes since the form is part of a formset, but
     always ends with the same value, this is retrieved with the next iterator
@@ -237,7 +237,7 @@ class BatteryComplex(LoginRequiredMixin, TemplateView):
         add_experiment_repos(context, self.battery)
 
         '''
-            We could attempt to seperate out ordering (handled as a
+            We could attempt to separate out ordering (handled as a
             BatteryExperiment) and ExperimentInstance creation.
         context["test_exp_instance_formset"] = forms.TestExpInstanceFormset(
             queryset=qs
@@ -738,7 +738,7 @@ class ExperimentRepoBulkTag(LoginRequiredMixin, FormView):
         return super().form_valid(form)
 
 '''
-Following four are for downloaing results, not posting them to them to server
+Following four are for downloading results, not posting them to them to server
 '''
 class ResultDetail(LoginRequiredMixin, DetailView):
     model = models.Result

--- a/expfactory_deploy/prolific/models.py
+++ b/expfactory_deploy/prolific/models.py
@@ -85,7 +85,7 @@ class StudyCollection(models.Model):
     collection_time_to_warning = models.DurationField(
         null=True,
         blank=True,
-        help_text="hh:mm:ss - Overall time participant has to complete all studies before recieving a warning message.",
+        help_text="hh:mm:ss - Overall time participant has to complete all studies before receiving a warning message.",
     )
     collection_warning_message = models.TextField(blank=True)
     collection_grace_interval = models.DurationField(

--- a/expfactory_deploy/prolific/outgoing_api.py
+++ b/expfactory_deploy/prolific/outgoing_api.py
@@ -94,7 +94,7 @@ def make_call(api_func, ac=False, **kwargs):
         )
         message = EmailMessage(
             f"Prolific API response error {response.status_code.value}",
-            f"Fucntion Call\n{api_func}\n\nkwargs:\n{kwargs}\n\nResponse:\n{response_str}",
+            f"Function Call\n{api_func}\n\nkwargs:\n{kwargs}\n\nResponse:\n{response_str}",
             settings.SERVER_EMAIL,
             [a[1] for a in settings.MANAGERS],
         )

--- a/expfactory_deploy/prolific/views.py
+++ b/expfactory_deploy/prolific/views.py
@@ -441,12 +441,12 @@ def remote_studies_list(request, collection_id=None):
     elif "COMPLETED" in studies_by_status and len(
         studies_by_status["COMPLETED"]
     ) == len(tracked_remote_ids):
-        state_description = "Collection for studies on prolific has completed. If you need to collect data for more participants use the 'clear remote ids' on the study colleciton list page to reset the databses state to not track any prolific study ids. From there drafts will need to be created, published and participants added."
+        state_description = "Collection for studies on prolific has completed. If you need to collect data for more participants use the 'clear remote ids' on the study collection list page to reset the databases state to not track any prolific study ids. From there drafts will need to be created, published and participants added."
 
     else:
         bad_state = True
 
-        state_description = "It appears not all studies in the study collection have the same status on prolific. This shouldn't happen normally. If there is a timed out message at the top of the page, reload the page to see if all the api requests go through. Otherwise you can attempt to use the 'clear remote ids' on the study colleciton list page to reset the databses state to not track any prolific study ids. From there drafts will need to be created, published and participants added. Any current active or unpublished studies should be manually closed or deleted on prolific."
+        state_description = "It appears not all studies in the study collection have the same status on prolific. This shouldn't happen normally. If there is a timed out message at the top of the page, reload the page to see if all the api requests go through. Otherwise you can attempt to use the 'clear remote ids' on the study collection list page to reset the databases state to not track any prolific study ids. From there drafts will need to be created, published and participants added. Any current active or unpublished studies should be manually closed or deleted on prolific."
 
     studies_by_status.default_factory = None
     context = {
@@ -564,7 +564,7 @@ def collection_recently_completed(request, collection_id, days, by):
 """
 
 """
-    collection_progress is the first stab at a progress page. Superceded by collection_progress_by_* views
+    collection_progress is the first stab at a progress page. Superseded by collection_progress_by_* views
 """
 
 
@@ -858,7 +858,7 @@ def toggle_collection(request, collection_id):
 
 
 """
-    View that displays all the subjects that have been associated with a study colleciton.
+    View that displays all the subjects that have been associated with a study collection.
     This is typically done when a prolific ID is added to the first study in a study collection.
 """
 

--- a/expfactory_deploy/templates/base.html
+++ b/expfactory_deploy/templates/base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}Expfactory Deploy{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Django project for the managment and deployment of batteries of experiments.">
+    <meta name="description" content="Django project for the management and deployment of batteries of experiments.">
     <meta name="author" content="Ross Blair">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/expfactory_deploy/templates/experiments/battery_detail.html
+++ b/expfactory_deploy/templates/experiments/battery_detail.html
@@ -12,7 +12,7 @@
     <a class="btn btn-primary" href="{% url 'experiments:battery-update' object.id %}">Edit</a>
     {% endif %}
     <a class="btn btn-primary" href="{% url 'experiments:preview-battery' object.id %}">Preview</a>
-    <a class="btn btn-primary" href="{% url 'experiments:preview-consent' object.id %}">Preview Insturcitons/Consent</a>
+    <a class="btn btn-primary" href="{% url 'experiments:preview-consent' object.id %}">Preview Instructions/Consent</a>
   </div>
 </div>
 {% comment %}

--- a/expfactory_deploy/templates/experiments/battery_form.html
+++ b/expfactory_deploy/templates/experiments/battery_form.html
@@ -10,7 +10,7 @@
         <a class="btn btn-primary" href="{% url 'experiments:battery-publish' battery.id %}">Publish</a>
       {% endif %}
       <a class="btn btn-primary" href="{% url 'experiments:preview-battery' battery.id %}">Preview</a>
-      <a class="btn btn-primary" href="{% url 'experiments:preview-consent' battery.id %}">Preview Insturcitons/Consent</a>
+      <a class="btn btn-primary" href="{% url 'experiments:preview-consent' battery.id %}">Preview Instructions/Consent</a>
       <a class="btn btn-primary" href="{% url 'experiments:battery-detail' battery.id %}">Details</a>
       <a class="btn btn-primary" href="{% url 'prolific:update-simple-cc' battery.id %}">Set Prolific URL</a>
     {% else %}

--- a/expfactory_deploy/templates/prolific/collection_progress_by_experiment_submissions.html
+++ b/expfactory_deploy/templates/prolific/collection_progress_by_experiment_submissions.html
@@ -9,7 +9,7 @@
     </div>
   </div>
   <p>
-    Table contains the number of submitted results for each particpant for each battery used in the collection.
+    Table contains the number of submitted results for each participant for each battery used in the collection.
   </p>
   <table class="table">
     <thead>

--- a/expfactory_deploy/templates/prolific/study_collection_subject_detail.html
+++ b/expfactory_deploy/templates/prolific/study_collection_subject_detail.html
@@ -77,7 +77,7 @@ Reissue Incomplete Studies for Participant
 </summary>
 <div class="alert alert-warning" role="alert">
   <p>
-  If a participant has a Prolific Submission is REJECTED or TIMED-OUT they will not be able to finish any remaining studies in the study collection.  This action will find which batteries the participant hasn't submitted data for, create a new study collection with these batteries, create drafts for the studies for the batteries, and associate this subject with that study collection. The api for any one of these steps may fail so scan the output for any obvious erros and review the new study collection to ensure its in good shape.
+  If a participant has a Prolific Submission is REJECTED or TIMED-OUT they will not be able to finish any remaining studies in the study collection.  This action will find which batteries the participant hasn't submitted data for, create a new study collection with these batteries, create drafts for the studies for the batteries, and associate this subject with that study collection. The api for any one of these steps may fail so scan the output for any obvious errors and review the new study collection to ensure its in good shape.
 </p>
 <p>
   Caveats:

--- a/expfactory_deploy/templates/subject_facing_base.html
+++ b/expfactory_deploy/templates/subject_facing_base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}Expfactory Deploy{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Django project for the managment and deployment of batteries of experiments.">
+    <meta name="description" content="Django project for the management and deployment of batteries of experiments.">
     <meta name="author" content="Ross Blair">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->


### PR DESCRIPTION
Ran [codespell](https://github.com/codespell-project/codespell) across the project (excluding vendored static libraries, generated `docs/_build/` output, migrations, and locale files). After reviewing each suggestion, applied 25 fixes across 17 files, and manually fixed 2 jumble-typos codespell could not detect (`Insturcitons` on battery pages).

Thanks to [@yarikoptic](https://github.com/yarikoptic) for pointing me to codespell.

**Highlights:**

- User-visible button label `Preview Insturcitons/Consent` → `Preview Instructions/Consent` (in `battery_form.html` and `battery_detail.html`)
- User-visible prolific status strings: `colleciton` → `collection` (×3), `databses` → `databases` (×2), `Superceded` → `Superseded`
- Code comments and docstrings in `experiments/views.py`, `prolific/models.py`, `prolific/views.py`, `prolific/outgoing_api.py`
- `README.rst`, `config/settings/production.py`, `docs/*.rst` (Sphinx sources), and HTML template `<meta name="description">` tags

---

Verified locally: the Django stack (Podman Compose via `local.yml`) renders without errors, and the updated `Preview Instructions/Consent` button label renders correctly on battery pages.
